### PR TITLE
Set YOTTA_CFG_UVISOR_PRESENT to 0 (uVisor unsupported)

### DIFF
--- a/target.json
+++ b/target.json
@@ -55,7 +55,7 @@
       }
     },
     "uvisor": {
-      "present": 1
+      "present": 0
     },
     "hardware": {
       "externalClock": "8000000",


### PR DESCRIPTION
The `YOTTA_CFG_UVISOR_PRESENT` symbol should be 0 while the uVisor
is not officially supported for this target.

Having the config set to 1 triggers some overrides and API calls
that are not supported if uVisor is not present, causing either
compile-time or run-time errors.

If you are in the process of porting or experimenting uVisor on your
target, you should consider using an app-specific yotta config:
```yotta --config='{"uvisor":{"present": 1}}' build```
so that the setting does not affect the default value of the public
module.

For reference:
[Issue on mbed forum](http://forums.mbed.com/t/nucleo-f410re-yotta-build-error/1038)
[Related PR on uvisor-lib](https://github.com/ARMmbed/uvisor-lib/pull/23)

@meriac 
@Patater 