### PR TITLE
Add no-inherit tag.

### DIFF
--- a/target.json
+++ b/target.json
@@ -42,7 +42,9 @@
     "armv7-m",
     "arm",
     "gcc",
-    "mbed"
+    "mbed",
+    "stm32f401re-no-inherit",
+    "stm32f401xe-no-inherit"
   ],
   "config": {
     "mbed-os": {},


### PR DESCRIPTION
This add a `<chip>-no-inherit` tag to `similarTo` to ensure future compatibility with target inheritance.

This feature does not change anything now, but will allow to selectively choose the target dependencies of `mbed-hal-stm32f4` and `cmsis-core-stm32f4` in the future.

@bogdanm @bremoran @0xc0170 @mjs-arm 