### PR TITLE
Correct the target platform name for ST Micro Nucleo F401RE with mbed…

### DIFF
--- a/target.json
+++ b/target.json
@@ -132,13 +132,13 @@
     "debug": [
       "valinor",
       "--target",
-      "ST_NUCLEO_F401RE",
+      "NUCLEO_F401RE",
       "$program"
     ],
     "test": [
       "mbed_test_wrapper",
       "--target",
-      "ST_NUCLEO_F401RE",
+      "NUCLEO_F401RE",
       "$program"
     ]
   }


### PR DESCRIPTION
I found an issue where `yotta test` didn't work on my Nucleo-F401RE board because of a python error (see below).
However, I could address it by replacing the target name `ST_NUCLEO_F401RE` with `NUCLEO_F401RE` in `target.json` because `mbedls` returns the latter as the platform name.

Please review the PR and discard it if the issue is caused by mbedls.

The reported python error:
```
Traceback (most recent call last):
  File "/usr/local/bin/mbed_test_wrapper", line 11, in <module>
    sys.exit(run())
  File "/usr/local/lib/python2.7/site-packages/mbed_test_wrapper/main.py", line 104, in run
    serial_port = serial_port + (':%s' % baud_rate)
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

mbedls version:
```
$ mbedls --version
0.2.1
```